### PR TITLE
Set og:image property

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,9 +3,10 @@
 <head>
 <meta charset="utf-8">
 <title>大江戸Ruby会議04</title>
-<meta name="keywords" content="">
-<meta name="description" content="">
-<link rel="stylesheet" href="css/oedo04.css" media="all">
+<meta name="keywords" content="" />
+<meta name="description" content="" />
+<meta property="og:image" content="http://qwik.jp/asakusarb/FrontPage.download/asakusarb-m.png" />
+<link rel="stylesheet" href="css/oedo04.css" media="all" />
 <style>
 /* Write code */
 </style>


### PR DESCRIPTION
SNS などで意図せぬ画像が表示されてそうなので、以下のいつもの Asakusa の画像を meta タグの `og:image` 属性で設定しました。
![](http://qwik.jp/asakusarb/FrontPage.download/asakusarb-m.png)

(もっとふさわしい画像があるのであれば置き換えてもよさそう)
