### PR TITLE
Add link to the slide decks

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -149,7 +149,8 @@
 </td>
 <td>
 <div>
-  <span class="speakers_name">Hiroshi Shibata</span>From "legacy" to the "edge".<br>
+  <span class="speakers_name">Hiroshi Shibata</span>From "legacy" to the "edge".
+  (<a href="https://speakerdeck.com/hsbt/from-legacy-to-edge-2014-edition">Slide Deck</a>)<br>
   <span class="speakers_name">Ryota Arai</span>"Infrataster - Infra Testing Framework"<br>
   <span class="speakers_name">Winston Teo</span>"Random Ruby Tips"<br>
 </div>


### PR DESCRIPTION
see asakusarb/oedo04#15

とりいそぎ、@hsbt ぶんをサンプルに足してみました

プログラムが下のほうなので、スピーカーの名前の下にもリンクを貼ろうとおもったのですが、
floatするul/liの中身の調整の仕方がわかんなかったので追加してないです ><

![](http://i.gyazo.com/7d04dfeace31add1e6468a005b1e34a2.png)

↑3人ずつ並んでくれなくなっちゃった

続きをどなたかやってもらえると助かります……ばたり。
